### PR TITLE
fix #123 - Fix line height in styleguide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dassana-io/web-components",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dassana-io/web-components",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"publishConfig": {
 		"registry": "https://npm.pkg.github.com/dassana-io"
 	},

--- a/src/components/assets/styles/styleguide.ts
+++ b/src/components/assets/styles/styleguide.ts
@@ -31,12 +31,12 @@ export const styleguide = {
 		justifyContent: 'space-between'
 	},
 	font: {
-		body: { fontSize: 14, lineHeight: 22 },
-		bodyLarge: { fontSize: 16, lineHeight: 24 },
-		h1: { fontSize: 32, lineHeight: 40 },
-		h2: { fontSize: 24, lineHeight: 32 },
-		h3: { fontSize: 20, lineHeight: 28 },
-		label: { fontSize: 12, lineHeight: 20 }
+		body: { fontSize: 14, lineHeight: '22px' },
+		bodyLarge: { fontSize: 16, lineHeight: '24px' },
+		h1: { fontSize: 32, lineHeight: '40px' },
+		h2: { fontSize: 24, lineHeight: '32px' },
+		h3: { fontSize: 20, lineHeight: '28px' },
+		label: { fontSize: 12, lineHeight: '20px' }
 	},
 	// eslint-disable-next-line sort-keys
 	spacing: { s: 8, m: 16, l: 24, xl: 32 }


### PR DESCRIPTION
line-height needs to be explicitly stated as pixels. Unitless values will be multiplied by the element's font size and results in something like this:
![Screen Shot 2020-10-19 at 9 57 51 PM](https://user-images.githubusercontent.com/68707128/96542824-c7e41380-1257-11eb-89cb-b1fc629db834.png)

closes #123 

