### PR TITLE
fix #648 - Markdown link underline style for both dark and light themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dassana-io/web-components",
-	"version": "0.12.63",
+	"version": "0.12.64",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dassana-io/web-components",
-			"version": "0.12.63",
+			"version": "0.12.64",
 			"dependencies": {
 				"@ant-design/icons": "^4.6.2",
 				"@dassana-io/web-utils": "^0.9.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dassana-io/web-components",
-	"version": "0.12.63",
+	"version": "0.12.64",
 	"publishConfig": {
 		"registry": "https://npm.pkg.github.com/dassana-io"
 	},

--- a/src/components/Markdown/index.tsx
+++ b/src/components/Markdown/index.tsx
@@ -4,6 +4,7 @@ import gfm from 'remark-gfm'
 import ReactMarkdown from 'react-markdown'
 import {
 	generateThemedMarkdownCodeStyles,
+	generateThemedMarkdownLinkStyles,
 	generateThemedMarkdownPreStyles,
 	generateThemedMarkdownStyles
 } from './styles'
@@ -18,10 +19,7 @@ const useStyles = createUseStyles({
 	'@global': {
 		'.markdown-body': {
 			...generateThemedMarkdownStyles(light),
-			'& a': {
-				color: 'unset',
-				textDecoration: 'underline'
-			},
+			'& a': generateThemedMarkdownLinkStyles(light),
 			'& code': {
 				...generateThemedMarkdownCodeStyles(light),
 				color: 'unset',
@@ -38,6 +36,7 @@ const useStyles = createUseStyles({
 		[`.${dark}`]: {
 			'& .markdown-body': {
 				...generateThemedMarkdownStyles(dark),
+				'& a': generateThemedMarkdownLinkStyles(dark),
 				'& code': generateThemedMarkdownCodeStyles(dark),
 				'& pre': generateThemedMarkdownPreStyles(dark)
 			}

--- a/src/components/Markdown/styles.ts
+++ b/src/components/Markdown/styles.ts
@@ -26,6 +26,11 @@ export const generateThemedMarkdownCodeStyles = (theme: ThemeType) => ({
 	backgroundColor: themes[theme].state.loading.primary
 })
 
+export const generateThemedMarkdownLinkStyles = (theme: ThemeType) => ({
+	color: 'unset',
+	textDecoration: 'underline'
+})
+
 export const generateThemedMarkdownPreStyles = (theme: ThemeType) => ({
 	'& code': {
 		backgroundColor: 'transparent'


### PR DESCRIPTION
closes #648 